### PR TITLE
Update deprecated method didRefreshRegistrationToken

### DIFF
--- a/HaloNotifications.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/HaloNotifications.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Source/FirebaseNotificationsAddon.swift
+++ b/Source/FirebaseNotificationsAddon.swift
@@ -226,7 +226,7 @@ open class FirebaseNotificationsAddon: NSObject, HaloNotificationsAddon, HaloLif
     }
 
     @objc
-    public func messaging(_ messaging: Messaging, didRefreshRegistrationToken fcmToken: String) {
+    public func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String) {
         Manager.core.logMessage("Did refresh Firebase token: \(fcmToken)", level: .info)
         updateToken(fcmToken: fcmToken)
     }


### PR DESCRIPTION
Since method messaging:didRefreshRegistrationToken has been deprecated, we have to replace it with the new one messaging:didReceiveRegistrationToken to avoid potential problems.