### PR TITLE
Added support for delegation of UNNotificationCenter calls

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,3 @@
-binary "https://raw.githubusercontent.com/mobgen/halo-notifications-ios/2.3.7/halo-firebase.json" "4.8.2"
-github "mobgen/halo-ios" "2.3.6"
+binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseAnalyticsBinary.json" "5.2.0"
+binary "https://dl.google.com/dl/firebase/ios/carthage/FirebaseMessagingBinary.json" "5.2.0"
+github "mobgen/halo-ios" "2.4.0"

--- a/HaloNotifications.xcodeproj/project.pbxproj
+++ b/HaloNotifications.xcodeproj/project.pbxproj
@@ -28,7 +28,7 @@
 		2846F40C1E6D6811009DFA3D /* HaloNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2846F40B1E6D6811009DFA3D /* HaloNotification.swift */; };
 		284A07831EEFD5F6002B2C98 /* HaloNotificationServiceExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 284A07821EEFD5F6002B2C98 /* HaloNotificationServiceExtension.swift */; };
 		28C24C181EF2B28A006880DF /* UserNotifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 005271181DEF3F07005826B7 /* UserNotifications.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
-		2B8E56F0202B12730024C9C7 /* nanopb.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2B8E56EF202B12730024C9C7 /* nanopb.framework */; };
+		2BE45B8520CE750800FECD39 /* nanopb.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2B8E56EF202B12730024C9C7 /* nanopb.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -86,14 +86,14 @@
 			files = (
 				282A5CDA1EF977AB00EFB996 /* GoogleToolboxForMac.framework in Frameworks */,
 				282A5CD51EF977AB00EFB996 /* FirebaseCore.framework in Frameworks */,
-				2B8E56F0202B12730024C9C7 /* nanopb.framework in Frameworks */,
 				282A5CD81EF977AB00EFB996 /* FirebaseMessaging.framework in Frameworks */,
 				282A5CD71EF977AB00EFB996 /* FirebaseInstanceID.framework in Frameworks */,
 				282A5CD91EF977AB00EFB996 /* FirebaseNanoPB.framework in Frameworks */,
 				28C24C181EF2B28A006880DF /* UserNotifications.framework in Frameworks */,
 				282A5CD61EF977AB00EFB996 /* FirebaseCoreDiagnostics.framework in Frameworks */,
-				282A5CDB1EF977AB00EFB996 /* Protobuf.framework in Frameworks */,
 				006EDC901E128CB500F583BC /* Halo.framework in Frameworks */,
+				2BE45B8520CE750800FECD39 /* nanopb.framework in Frameworks */,
+				282A5CDB1EF977AB00EFB996 /* Protobuf.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -237,7 +237,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0830;
-				LastUpgradeCheck = 0920;
+				LastUpgradeCheck = 0940;
 				ORGANIZATIONNAME = "Mobgen Technology";
 				TargetAttributes = {
 					006EDC821E12841900F583BC = {
@@ -247,7 +247,7 @@
 					};
 					00A409631D119BAF005D4FB0 = {
 						CreatedOnToolsVersion = 7.3.1;
-						LastSwiftMigration = 0830;
+						LastSwiftMigration = 0940;
 					};
 				};
 			};
@@ -372,12 +372,14 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -430,12 +432,14 @@
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
 				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
 				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
@@ -495,7 +499,8 @@
 				PRODUCT_NAME = HaloNotifications;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -525,7 +530,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.mobgen.HaloNotifications;
 				PRODUCT_NAME = HaloNotifications;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/HaloNotifications.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/HaloNotifications.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:/Users/borja/Documents/git/halo-notifications-sdk-ios/HaloNotifications.xcodeproj">
+      location = "self:/Users/mike.pesate/Documents/MOBGEN/HALO/HaloNotifications/HaloNotifications.xcodeproj">
    </FileRef>
 </Workspace>

--- a/HaloNotifications.xcodeproj/xcshareddata/xcschemes/Halo Notifications.xcscheme
+++ b/HaloNotifications.xcodeproj/xcshareddata/xcschemes/Halo Notifications.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0920"
+   LastUpgradeVersion = "0940"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -26,9 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES">
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -57,7 +56,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Source/FirebaseNotificationsAddon.swift
+++ b/Source/FirebaseNotificationsAddon.swift
@@ -73,6 +73,7 @@ open class FirebaseNotificationsAddon: NSObject, HaloNotificationsAddon, HaloLif
                                                      options: [.customDismissAction])
         userNotificationCenter.setNotificationCategories([generalCategory])
         notificationEvents = true
+        UNUserNotificationCenter.current().delegate = self
     }
 
     public func willRegisterAddon(haloCore core: CoreManager) {
@@ -96,11 +97,14 @@ open class FirebaseNotificationsAddon: NSObject, HaloNotificationsAddon, HaloLif
         _ app: UIApplication,
         authOptions options: UNAuthorizationOptions = [.alert, .badge, .sound]) -> Void {
         
-        UNUserNotificationCenter.current().requestAuthorization(
+        let center = UNUserNotificationCenter.current()
+        center.delegate = self
+        center.requestAuthorization(
             options: options,
             completionHandler: {_, _ in })
         
         app.registerForRemoteNotifications()
+        
     }
     
     @available(iOS, obsoleted: 10.0)
@@ -111,6 +115,7 @@ open class FirebaseNotificationsAddon: NSObject, HaloNotificationsAddon, HaloLif
         app.registerUserNotificationSettings(settings)
         
         app.registerForRemoteNotifications()
+        
     }
     
     // MARK: Lifecycle
@@ -128,6 +133,11 @@ open class FirebaseNotificationsAddon: NSObject, HaloNotificationsAddon, HaloLif
     
     @objc(applicationDidFinishLaunching:core:launchOptions:)
     public func applicationDidFinishLaunching(_ app: UIApplication, core: CoreManager, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]?) -> Bool {
+        if #available(iOS 10.0, *) {
+            // For iOS 10 display notification (sent via APNS)
+            UNUserNotificationCenter.current().delegate = self
+        }
+        
         return true
     }
     
@@ -158,13 +168,16 @@ open class FirebaseNotificationsAddon: NSObject, HaloNotificationsAddon, HaloLif
     open func application(_ app: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: NSError, core: CoreManager) {
         core.logMessage("Error registering for remote notifications. \(error.localizedDescription)", level: .error)
         
-        #if (arch(i386) || arch(x86_64)) && os(iOS)
+        #if targetEnvironment(simulator)
             self.completionHandler?(self, true)
         #else
             self.completionHandler?(self, false)
         #endif
     }
     
+    
+    
+    @objc
     open func application(_ app: UIApplication, didReceiveRemoteNotification userInfo: [AnyHashable: Any], core: CoreManager, userInteraction user: Bool, fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
         
         func checkTwoFactorAndNotify(notification: HaloNotification,app: UIApplication,user:Bool,completionHandler: @escaping (UIBackgroundFetchResult) -> Void){
@@ -175,9 +188,9 @@ open class FirebaseNotificationsAddon: NSObject, HaloNotificationsAddon, HaloLif
                     Manager.core.logMessage("No 'code' field was found within the payload", level: .error)
                 }
             }
-            self.delegate?.application(app, didReceiveRemoteNotification: notification, userInteraction: user, fetchCompletionHandler: completionHandler)
+            self.delegate?.application?(app, didReceiveRemoteNotification: notification, userInteraction: user, fetchCompletionHandler: completionHandler)
         }
-
+        
         let notification = HaloNotification(userInfo: userInfo)
         guard let deviceAlias = core.device?.alias else {
             checkTwoFactorAndNotify(notification: notification,app: app, user: user, completionHandler: completionHandler)
@@ -188,8 +201,8 @@ open class FirebaseNotificationsAddon: NSObject, HaloNotificationsAddon, HaloLif
             return
         }
         
-        let haloNotificationEvent : HaloNotificationEvent = HaloNotificationEvent(device: deviceAlias, schedule: scheduleId, action: EventType.receipt.rawValue)
         if(notificationEvents){
+            let haloNotificationEvent : HaloNotificationEvent = HaloNotificationEvent(device: deviceAlias, schedule: scheduleId, action: EventType.receipt.rawValue)
             core.notificationAction(notificationEvent: haloNotificationEvent, completionHandler: { (event, error) in
                 checkTwoFactorAndNotify(notification: notification, app: app, user: user, completionHandler: completionHandler)
             })
@@ -200,15 +213,18 @@ open class FirebaseNotificationsAddon: NSObject, HaloNotificationsAddon, HaloLif
     
     @available(iOS 10.0, *)
     open func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, core: CoreManager,fetchCompletionHandler completionHandler: @escaping () -> Void) {
-         if(notificationEvents){
-            guard let deviceAlias = core.device?.alias else {
-                completionHandler()
-                return
-            }
-            guard let scheduleId = response.notification.request.content.userInfo["scheduleId"] as! String? else {
-                completionHandler()
-                return
-            }
+        
+        guard let deviceAlias = core.device?.alias else {
+            delegate?.userNotificationCenter?(center, didReceive: response, withCompletionHandler: completionHandler)
+            return
+        }
+        
+        guard let scheduleId = response.notification.request.content.userInfo["scheduleId"] as! String? else {
+            delegate?.userNotificationCenter?(center, didReceive: response, withCompletionHandler: completionHandler)
+            return
+        }
+        
+        if(notificationEvents){
             var  haloNotificationEvent : HaloNotificationEvent?
             if(response.actionIdentifier ==  UNNotificationDismissActionIdentifier ) {
                 haloNotificationEvent = HaloNotificationEvent(device:  deviceAlias, schedule: scheduleId, action: EventType.dismiss.rawValue)
@@ -216,13 +232,33 @@ open class FirebaseNotificationsAddon: NSObject, HaloNotificationsAddon, HaloLif
                 haloNotificationEvent = HaloNotificationEvent(device:  deviceAlias, schedule: scheduleId, action: EventType.open.rawValue)
             }
             if let actionEvent = haloNotificationEvent {
-                core.notificationAction(notificationEvent: actionEvent, completionHandler: { (event, error) in
-                    completionHandler()
+                core.notificationAction(notificationEvent: actionEvent, completionHandler: { [unowned self] (event, error) in
+                    self.delegate?.userNotificationCenter?(center, didReceive: response, withCompletionHandler: completionHandler)
                 })
             }
-         } else {
-            completionHandler()
+        } else {
+            self.delegate?.userNotificationCenter?(center, didReceive: response, withCompletionHandler: completionHandler)
         }
+    }
+    
+    @available(iOS 10.0, *)
+    public func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        
+        func checkTwoFactorAndNotify(notification haloNotification: HaloNotification,center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+            if haloNotification.type == .twoFactor {
+                if let code = haloNotification.payload["code"] as? String {
+                    self.twoFactorDelegate?.application(nil, didReceiveTwoFactorAuthCode: code, remoteNotification: haloNotification)
+                } else {
+                    Manager.core.logMessage("No 'code' field was found within the payload", level: .error)
+                }
+                
+            }
+            self.delegate?.userNotificationCenter?(center, willPresent: notification, withCompletionHandler: completionHandler)
+        }
+        
+        let haloNotification = HaloNotification(unNotification:notification)
+        checkTwoFactorAndNotify(notification: haloNotification, center: center, willPresent: notification, withCompletionHandler: completionHandler)
+        
     }
 
     @objc
@@ -234,7 +270,7 @@ open class FirebaseNotificationsAddon: NSObject, HaloNotificationsAddon, HaloLif
     private func updateToken(fcmToken: String?) {
         if let device = Halo.Manager.core.device,
             let token = fcmToken {
-
+            print("[FCMTOKEN]: \(token)")
             device.info = DeviceInfo(platform: "ios", token: token)
 
             Manager.core.saveDevice { _, result in

--- a/Source/HaloNotification.swift
+++ b/Source/HaloNotification.swift
@@ -73,4 +73,9 @@ public class HaloNotification: NSObject {
         super.init()
     }
     
+    @available(iOS 10.0, *)
+    public convenience init(unNotification: UNNotification) {
+        self.init(userInfo: unNotification.request.content.userInfo)
+        
+    }
 }

--- a/Source/NotificationsProtocols.swift
+++ b/Source/NotificationsProtocols.swift
@@ -20,7 +20,19 @@ public protocol NotificationsDelegate {
     ///   - notification: Object containing information about the push notification
     ///   - user: Whether the execution of this delegate has been triggered by a user action or not
     ///   - completionHandler: Handler to be executed for silent notifications (to
+    @objc optional
     func application(_ app: UIApplication, didReceiveRemoteNotification notification: HaloNotification, userInteraction user: Bool, fetchCompletionHandler completionHandler: ((UIBackgroundFetchResult) -> Void)?) -> Void
+    
+    // The method will be called on the delegate only if the application is in the foreground. If the method is not implemented or the handler is not called in a timely manner then the notification will not be presented. The application can choose to have the notification presented as a sound, badge, alert and/or in the notification list. This decision should be based on whether the information in the notification is otherwise visible to the user.
+    @available(iOS 10.0, *)
+    @objc optional
+    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Swift.Void)
+    
+    
+    // The method will be called on the delegate when the user responded to the notification by opening the application, dismissing the notification or choosing a UNNotificationAction. The delegate must be set before the application returns from application:didFinishLaunchingWithOptions:.
+    @available(iOS 10.0, *)
+    @objc optional
+    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Swift.Void)
 }
 
 @objc(HaloTwoFactorAuthenticationDelegate)
@@ -32,6 +44,6 @@ public protocol TwoFactorAuthenticationDelegate {
     ///   - app: Application receiving the push notification
     ///   - code: Code provided by the server to complete the authentication process
     ///   - notification: Object containing information about the push notification
-    func application(_ app: UIApplication, didReceiveTwoFactorAuthCode code: String, remoteNotification notification: HaloNotification) -> Void
+    func application(_ app: UIApplication?, didReceiveTwoFactorAuthCode code: String, remoteNotification notification: HaloNotification) -> Void
     
 }

--- a/Source/NotificationsUtils.swift
+++ b/Source/NotificationsUtils.swift
@@ -13,6 +13,7 @@ import Foundation
 @available(iOSApplicationExtension 10.0, *)
 class NotificationsUtils: NSObject {
     
+    @objc
     class func didReceive(_ request: UNNotificationRequest, withContent content: UNMutableNotificationContent?, contentHandler: @escaping (UNNotificationContent) -> Void, delegate: URLSessionDownloadDelegate) {
         
         guard let content = content,
@@ -30,6 +31,7 @@ class NotificationsUtils: NSObject {
         
     }
     
+    @objc
     class func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL, content: UNMutableNotificationContent?, contentHandler:  ((UNNotificationContent) -> Void)?) {
         
         guard let contentHandler = contentHandler,
@@ -57,6 +59,7 @@ class NotificationsUtils: NSObject {
         
     }
     
+    @objc
     class func storeFile(temporaryLocation location: URL, withFilename filename: String) -> URL? {
         
         let fileManager = FileManager.default
@@ -77,6 +80,7 @@ class NotificationsUtils: NSObject {
         return nil
     }
     
+    @objc
     class func loadAttachment(forMedia media: String, delegate: URLSessionDownloadDelegate) {
         
         guard let url = URL(string: media) else {


### PR DESCRIPTION
Added support for delegation of UNNotificationCenter to NotificationProtocols. Added support for this also on FirebaseNotificationAddon. Also increased the redundancy of making the add-on the delegate of the NotificationCenter as a sanity check.